### PR TITLE
Math element syntax: match mrow instead of md; allow all attributes

### DIFF
--- a/pretext-tools/package.json
+++ b/pretext-tools/package.json
@@ -2,7 +2,7 @@
     "name": "pretext-tools",
     "displayName": "PreTeXt-tools",
     "description": "Language support and more for PreTeXt",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "publisher": "oscarlevin",
     "repository": "https://github.com/oscarlevin/vscode-pretext/tree/master/pretext-tools",
     "engines": {

--- a/pretext-tools/syntaxes/ptx.tmLanguage.json
+++ b/pretext-tools/syntaxes/ptx.tmLanguage.json
@@ -3,7 +3,7 @@
 	"injectionSelector": "L:text.xml -comment",
 	"patterns": [
 		{
-			"begin": "(<)(m|me|men|md|mdn|usage)\\s?(permid=\"...\")?(>)",
+			"begin": "(<)(m|me|men|mrow|usage)(\\s(?:(?!permid=\"...\").)*\\s)?\\s*(permid=\"...\")?(\\s.*?)?(>)",
 			"beginCaptures": {
 				"1": {
 					"name": "entity.name.tag.localname.xml.math"
@@ -12,9 +12,23 @@
 					"name": "entity.name.tag.localname.xml.math"
 				},
 				"3": {
-					"name": "comment.inline.permid"
+					"patterns": [
+						{
+							"include": "text.xml#tagStuff"
+						}
+					]
 				},
 				"4": {
+					"name": "comment.inline.permid"
+				},
+				"5": {
+					"patterns": [
+						{
+							"include": "text.xml#tagStuff"
+						}
+					]
+				},
+				"6": {
 					"name": "entity.name.tag.localname.xml.math"
 				}
 			},
@@ -30,6 +44,49 @@
 				},
 				{
 					"include": "text.tex#braces"
+				}
+			],
+			"contentName": "support.class.math.latex"
+		},
+		{
+			"begin": "(<)(md|mdn)(\\s(?:(?!permid=\"...\").)*\\s)?\\s*(permid=\"...\")?(\\s.*?)?(>)",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.tag.localname.xml.math"
+				},
+				"2": {
+					"name": "entity.name.tag.localname.xml.math"
+				},
+				"3": {
+					"patterns": [
+						{
+							"include": "text.xml#tagStuff"
+						}
+					]
+				},
+				"4": {
+					"name": "comment.inline.permid"
+				},
+				"5": {
+					"patterns": [
+						{
+							"include": "text.xml#tagStuff"
+						}
+					]
+				},
+				"6": {
+					"name": "entity.name.tag.localname.xml.math"
+				}
+			},
+			"end": "</\\2>",
+			"endCaptures": {
+				"0": {
+					"name": "entity.name.tag.localname.xml.math"
+				}
+			},
+			"patterns": [
+				{
+					"include": "$base"
 				}
 			],
 			"contentName": "support.class.math.latex"


### PR DESCRIPTION
* `<md>` doesn't contain math, it contains one or more `<mrow>` elements, so don't apply math syntax highlighting to `<md>` contents. Instead, match `mrow`.
* Allow other attributes besides `@permid` when matching math-containing elements. (This is for `<mrow>` in particular.)